### PR TITLE
AzureBlobStorageAddonのアップロードファイル上限の不具合修正

### DIFF
--- a/tests/core/streams/test_bytestream.py
+++ b/tests/core/streams/test_bytestream.py
@@ -1,0 +1,40 @@
+import pytest
+
+from waterbutler.core import streams
+
+
+class TestByteStream:
+
+    @pytest.mark.asyncio
+    async def test_works(self):
+        data = b'This here be bytes yar'
+        stream = streams.ByteStream(data)
+        read = await stream.read()
+        assert data == read
+
+    @pytest.mark.asyncio
+    async def test_1_at_a_time(self):
+        data = b'This here be bytes yar'
+        stream = streams.ByteStream(data)
+
+        for i in range(len(data)):
+            assert data[i:(i+1)] == await stream.read(1)
+
+    def test_size(self):
+        data = b'This here be bytes yar'
+        stream = streams.ByteStream(data)
+        assert stream.size == len(data)
+
+    @pytest.mark.asyncio
+    async def test_hits_eof(self):
+        data = b'This here be bytes yar'
+        stream = streams.ByteStream(data)
+        assert stream.at_eof() is False
+        await stream.read()
+        assert stream.at_eof() is True
+
+    def test_must_be_bytes(self):
+        with pytest.raises(TypeError):
+            streams.ByteStream(object())
+        with pytest.raises(TypeError):
+            streams.ByteStream('string')

--- a/tests/providers/azureblobstorage/test_provider.py
+++ b/tests/providers/azureblobstorage/test_provider.py
@@ -1,5 +1,3 @@
-import random
-import string
 import math
 
 import pytest
@@ -23,7 +21,6 @@ from waterbutler.providers.azureblobstorage.metadata import AzureBlobStorageFile
 from waterbutler.providers.azureblobstorage.metadata import AzureBlobStorageFolderMetadata
 from waterbutler.providers.azureblobstorage.provider import (
     MAX_UPLOAD_BLOCK_SIZE,
-    MAX_UPLOAD_ONCE_SIZE,
 )
 
 
@@ -436,6 +433,7 @@ class TestMetadata:
         block_id_prefix = 'hogefuga'
         block_id_list = [AzureBlobStorageProvider._format_block_id(block_id_prefix, i) for i in range(upload_times)]
         block_req_params_list = [{'comp': 'block', 'blockid': block_id} for block_id in block_id_list]
+        print(block_id_list)
         block_list_req_params = {'comp': 'blocklist'}
 
         path = WaterButlerPath('/large_foobah')
@@ -454,7 +452,7 @@ class TestMetadata:
                 ],
             )
 
-        metadata, created = await provider.upload(large_file_stream, path, block_id_list=block_id_list)
+        metadata, created = await provider.upload(large_file_stream, path, block_id_prefix=block_id_prefix)
 
         assert metadata.kind == 'file'
         assert created

--- a/tests/providers/azureblobstorage/test_provider.py
+++ b/tests/providers/azureblobstorage/test_provider.py
@@ -1,7 +1,6 @@
-import math
-
 import pytest
 
+import math
 import io
 import time
 import base64
@@ -433,7 +432,6 @@ class TestMetadata:
         block_id_prefix = 'hogefuga'
         block_id_list = [AzureBlobStorageProvider._format_block_id(block_id_prefix, i) for i in range(upload_times)]
         block_req_params_list = [{'comp': 'block', 'blockid': block_id} for block_id in block_id_list]
-        print(block_id_list)
         block_list_req_params = {'comp': 'blocklist'}
 
         path = WaterButlerPath('/large_foobah')

--- a/tests/providers/azureblobstorage/test_provider.py
+++ b/tests/providers/azureblobstorage/test_provider.py
@@ -432,10 +432,9 @@ class TestMetadata:
     @pytest.mark.aiohttpretty
     async def test_upload_large(self, provider, large_file_content, large_file_stream, large_file_metadata, mock_time):
         # upload 4MB data 17 times and 3MB once, and request block_list
-        chars = string.ascii_letters + string.digits
-        assert(len(large_file_content) > MAX_UPLOAD_ONCE_SIZE)
         upload_times = math.floor(len(large_file_content) / MAX_UPLOAD_BLOCK_SIZE)
-        block_id_list = [''.join([random.choice(chars) for _ in range(32)]) for _ in range(upload_times)]
+        block_id_prefix = 'hogefuga'
+        block_id_list = [AzureBlobStorageProvider._format_block_id(block_id_prefix, i) for i in range(upload_times)]
         block_req_params_list = [{'comp': 'block', 'blockid': block_id} for block_id in block_id_list]
         block_list_req_params = {'comp': 'blocklist'}
 

--- a/waterbutler/core/streams/__init__.py
+++ b/waterbutler/core/streams/__init__.py
@@ -1,6 +1,7 @@
 # import base first, as other streams depend on them.
 from waterbutler.core.streams.base import BaseStream  # noqa
 from waterbutler.core.streams.base import MultiStream  # noqa
+from waterbutler.core.streams.base import ByteStream  # noqa
 from waterbutler.core.streams.base import StringStream  # noqa
 from waterbutler.core.streams.base import EmptyStream  # noqa
 

--- a/waterbutler/core/streams/base.py
+++ b/waterbutler/core/streams/base.py
@@ -122,6 +122,24 @@ class StringStream(BaseStream):
         return (await asyncio.StreamReader.read(self, n))
 
 
+class ByteStream(BaseStream):
+    def __init__(self, data):
+        super().__init__()
+        if not isinstance(data, bytes):
+            raise TypeError('Data must be either bytes, found {!r}'.format(type(data)))
+
+        self._size = len(data)
+        self.feed_data(data)
+        self.feed_eof()
+
+    @property
+    def size(self):
+        return self._size
+
+    async def _read(self, n=-1):
+        return (await asyncio.StreamReader.read(self, n))
+
+
 class EmptyStream(BaseStream):
     """An empty stream with size 0 that returns nothing when read. Useful for representing
     empty folders when building zipfiles.

--- a/waterbutler/providers/azureblobstorage/provider.py
+++ b/waterbutler/providers/azureblobstorage/provider.py
@@ -1,7 +1,6 @@
 import base64
 import hashlib
 import asyncio
-
 import aiohttp
 import functools
 from urllib.parse import urlparse
@@ -216,7 +215,6 @@ class AzureBlobStorageProvider(provider.BaseProvider):
 
         :param waterbutler.core.streams.RequestWrapper stream: The stream to put to Azure Blob Storage
         :param str path: The full path of the key to upload to/into
-        :param int parallel_num: The number of parallel uploads
 
         :rtype: dict, bool
         """


### PR DESCRIPTION
## 概要
AzureBlobStorageAddonで、64MBを超えるファイルをアップロードできない不具合を修正しました。
GRDM6033 に対応したPRです。

## 詳細
AzureBlobStorageのAPIにて、一度にアップロードできるファイルの最大サイズが64MBと制限されていたため、以下の変更を加えました。
1. 4MB以下ごとに分割してアップロードすることで最大約195GBまでアップロードできるため、分割アップロード方式に対応しました。
2. 調査の結果、分割するよりも一度にアップロードしたほうが1秒以上早いことが分かったため、64MB以下ならば従来通り一度にアップロードするようにしています。
3. この修正に伴い単体テストも修正しました。

## 主なコードの変更点
- `waterbutler/providers/azureblobstorage/provider.py`
  - `MAX_UPLOAD_BLOCK_SIZE` を追加。 (分割アップロード時の最大サイズ。)
  - `MAX_UPLOAD_ONCE_SIZE` を追加。 (一度にアップロードする際の最大サイズ。)
  - `UPLOAD_PARALLEL_NUM` を追加。 (分割アップロード時の平行実行数。デフォルトは2であり、これはAzureBlobStorageの公式SDKに合わせました。)
  - `AzureBlobStorageProvider.upload()` を修正。
    - コンテンツのサイズが `MAX_UPLOAD_ONCE_SIZE` を超える場合は分割アップロードするよう修正。
  - `AzureBlobStorageProvider.{_upload_at_once(), _put_block(), _put_block_list(), _format_block_id()}` を追加。 (`upload()` 用。)
- `waterbutler/core/streams/base.py`
  - `ByteStream` クラスを追加 。(ファイルコンテンツの分割用。`StringStream` でもbyte列を扱えますが、str型を渡すと強制的に文字コードをutf-8に変換してしまうためです。）
- `tests/providers/azureblobstorage/test_provider.py`
  - `test_upload_large()` を追加。 (64MBを超えるファイルをアップロードするテスト。)
  - `large_file_content()`, `large_file_like()`, `large_file_stream()`, `large_file_metadata()`, を追加。 (`test_upload_large()` 用。)
- `tests/core/streams/test_bytestream.py` を追加。(`ByteStream` クラスのテスト。)

## 補足・懸念点
- `AzureBlobStorageProvider.upload()` の引数に `block_id_prefix` を渡せるようにしていますが、これは単体テストのためです。
- `AzureBlobStorageProvider.upload()` のコードが少々複雑です。
- ~~わざわざ `ByteStream` クラスを新設しなくてもよい方法があればそうしたいです。~~ => 議論の結果必要そうだろう、ということで、単体テストも追加。
- 単体テストで71MBのコンテンツを生成・コピーしているため、テストに若干時間がかかるようになりました。
- `osf.io` 本体のコードで、Webからアップロードできる最大サイズは128MBと制限しています (`addons/azureblobstorage/apps.py` の `max_file_size`。)。